### PR TITLE
Extend ChangeLog Generation parsing PR body

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 skipsdist=True
-envlist=lint,py36,py38
+envlist=lint,py38
 
 [testenv]
 basepython=
-    py36: python3.6
     py38: python3.8
 deps=.[testing]
 commands=


### PR DESCRIPTION
The title of a PR is sometimes not the best way to describe a change within the changelog

## Additions

- Pull body of each identified PRs
- Choose change identified in Body over PR title for ChangeLog generation

## Removals
NA

## Changes

-

## Testing

-

## Review

- @user

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
